### PR TITLE
Use conda-forge for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ install:
   - export PATH="$CONDA_PREFIX/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install python=$TRAVIS_PYTHON_VERSION
-  - conda install -q conda-build anaconda-client coverage sphinx
+  - conda install python=$TRAVIS_PYTHON_VERSION -c conda-forge
+  - conda install -q conda-build anaconda-client -c conda-forge
 
 script:
-  - conda build ./recipe -c csdms-stack -c defaults -c conda-forge --old-build-string
+  - conda build ./recipe -c conda-forge -c csdms-stack --old-build-string
 
 after_success:
   - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,7 +10,5 @@ cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DHDF5_LIBRARY=$PREFIX/lib/libhdf5$SHLIB_EXT
 make
-if [[ `uname -s` == 'Linux' ]]; then
-    ctest
-fi
+ctest
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ mkdir _build && cd _build
 cmake .. \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DCMAKE_BUILD_TYPE=Release \
-    -DHDF5_LIBRARY=$BUILD_PREFIX/lib/libhdf5$SHLIB_EXT
+    -DHDF5_LIBRARY=$PREFIX/lib/libhdf5$SHLIB_EXT
 make
 if [[ `uname -s` == 'Linux' ]]; then
     ctest

--- a/recipe/macos-clang.patch
+++ b/recipe/macos-clang.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6fac4a5..6ac3e7d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -126,6 +126,8 @@ else()
+     else()
+       message(FATAL_ERROR "g++ version must be at least 4.7")
+     endif()
++  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
++    # do nothing
+   else()
+     target_compile_features(iriclib PRIVATE cxx_nullptr) # cmake >= 3.1 reqd
+   endif()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,11 +15,11 @@ source:
     - propagate-libraries.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
-    - cmake=2.8
+    - cmake
     - {{ compiler('cxx') }}
     - cgns=3.2.1
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
     - unix-find-library.patch
     - macosx-rpath.patch
     - propagate-libraries.patch
+    - macos-clang.patch
 
 build:
   number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,10 @@ requirements:
   build:
     - cmake
     - {{ compiler('cxx') }}
-    - cgns=3.2.1
+  host:
+    - cgns==3.2.1=1
   run:
-    - cgns=3.2.1
+    - cgns==3.2.1=1
 
 about:
   home: http://i-ric.org


### PR DESCRIPTION
This PR changes the recipe to look for dependencies first in the conda-forge channel, except for cgns, which still comes from the csdms-stack channel.